### PR TITLE
feat: add custom fetch composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ interface User {
 const { user } = useSanctum<User>();
 ```
 
+### Making API requests
+
+To make API requests, you may use the `useSanctumFetch` composable. This composable is a wrapper around the `useFetch` composable provided by the Nuxt that automatically handles the CSRF token and passes down the user's session cookie.
+
+```ts
+const { data } = useSanctumFetch("/api/user");
+```
+
 ### Restricting access to routes
 
 This package provides the `auth` and `guest` middlewares to restrict access to routes.
@@ -161,6 +169,17 @@ When your Laravel API is served over HTTPS in a development environment, SSL err
 
 > [!NOTE]
 > Bun does not seem affected by this issue.
+
+### DNS resolution
+
+If you run your Laravel API with `php artisan serve`, be aware that by default, it will only bind
+to the IPv4 interface. This may cause DNS resolution issues when using the `useSanctumFetch` composable, because it may try to resolve the `localhost` hostname to an IPv6 address.
+
+There are a few ways to work around this:
+-  Bind to the IPv6 interface instead by running `php artisan serve --host ::1`
+-  Edit your `/etc/hosts` file to remove the IPv6 entry for `localhost`
+
+
 
 
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,4 @@
 export default defineNuxtConfig({
 	modules: ["../src/module"],
 	devtools: { enabled: true },
-	sanctum: {
-		url: "http://127.0.0.1:8000",
-	},
 });

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,16 +1,40 @@
 <script setup lang="ts">
-import { definePageMeta, useSanctum } from '#imports';
+import { ref } from 'vue';
+import { definePageMeta, useSanctum, useSanctumFetch } from '#imports';
 const { logout, check, user } = useSanctum();
 definePageMeta({ middleware: 'auth' });
 const signOut = () => logout();
+
+const ssrDummyData = ref<any | null>(null);
+ssrDummyData.value =  (await useSanctumFetch('/api/user')).data;
+
+const csrDummyData = ref<any | null>(null);
+const getCSRDummyData = async () => {
+    csrDummyData.value = (await useSanctumFetch('/api/user')).data;
+}
 </script>
 
 <template>
     <div>
-        home
-        <button @click="signOut">logout</button>
-        <RouterLink to="/account">account</RouterLink>
-        <button @click="check">Check</button>
-        <pre>{{ user }}</pre>
+        <h1>Home</h1>
+        <div class="flex">
+            <RouterLink to="/account">Go to account</RouterLink>
+            <button @click="signOut">logout</button>
+        </div>
+        
+        <h2>User</h2>
+        <div>
+            <pre>{{ user }}</pre>
+        </div>
+        
+        <h2>Server-rendered dummy data</h2>
+        <div>
+            <pre>{{ ssrDummyData }}</pre>
+        </div>
+
+        <h2>Client-rendered dummy data</h2>
+        <button @click="getCSRDummyData">Get dummy data</button>
+        <pre>{{ csrDummyData }}</pre>
+        
     </div>
 </template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -35,5 +35,12 @@ export default defineNuxtModule<Options>({
 			as: "useSanctum",
 			from: resolve("runtime/composables/sanctum"),
 		});
+
+		// Register fetch composable
+		addImports({
+			name: "useSanctumFetch",
+			as: "useSanctumFetch",
+			from: resolve("runtime/composables/fetch"),
+		});
 	},
 });

--- a/src/runtime/composables/fetch.ts
+++ b/src/runtime/composables/fetch.ts
@@ -1,0 +1,49 @@
+import type { UseFetchOptions } from "#app";
+import {
+	useCookie,
+	useFetch,
+	useRequestHeaders,
+	useRuntimeConfig,
+	useSanctum,
+} from "#imports";
+import { defu } from "defu";
+import { parse, splitCookiesString } from "set-cookie-parser-es";
+
+export const useSanctumFetch = <T>(
+	url: string | (() => string),
+	options?: UseFetchOptions<T>,
+) => {
+	const { csrfToken } = useSanctum();
+	const config = useRuntimeConfig().public.sanctum;
+
+	const defaults: UseFetchOptions<T> = {
+		baseURL: config.url,
+		mode: "cors",
+		redirect: "manual",
+		credentials: "include",
+		key: typeof url === "string" ? url : url(),
+		headers: {
+			...(process.server ? useRequestHeaders(["cookie"]) : {}),
+			...(csrfToken.value && { "X-XSRF-TOKEN": csrfToken.value }),
+		} as HeadersInit,
+		onResponse: (response) => {
+			if (process.server) {
+				const split = splitCookiesString(
+					response.response.headers.get("set-cookie") ?? "",
+				);
+				const cookies = parse(split);
+				csrfToken.value = cookies.find(
+					(cookie) => cookie.name === "XSRF-TOKEN",
+				)?.value;
+			}
+
+			if (process.client) {
+				csrfToken.value = useCookie("XSRF-TOKEN").value;
+			}
+		},
+	};
+
+	const params = defu(options, defaults);
+
+	return useFetch(url, params);
+};


### PR DESCRIPTION
This PR introduces a custom `useSanctumFetch` composable that wraps Nuxt's own `useFetch` and automatically handles CSRF tokens and session cookies.