### PR TITLE
feat: add after-login redirect override

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ await login({
 });
 ```
 
+#### Redirecting after signing in
+
+By default, the user will be redirected to the URL specified in the `login.redirectsTo` option. You may override this behavior by passing an alternative URL to the `login` method. Additionally, you may pass `false` to the `login` method to prevent redirection altogether.
+
+```ts
+// Override the default redirect
+await login({
+	email: "john.snow@example.com",
+	password: "winteriscoming",
+},"/somewhere-else");
+
+// Prevent redirection
+await login({
+	email: "john.snow@example.com",
+	password: "winteriscoming",
+}, false);
+```
+
 ### Signing Out
 
 To sign a user out, use the `logout` method exposed by the `useSanctum` composable.

--- a/src/runtime/composables/sanctum.ts
+++ b/src/runtime/composables/sanctum.ts
@@ -89,7 +89,10 @@ export const useSanctum = <TUser extends Record<string, unknown>>() => {
 	 * @param data The credentials to use to sign the user in.
 	 * @returns Whether the user was successfully signed in.
 	 */
-	const login = async (data: Record<string, string>): Promise<boolean> => {
+	const login = async (
+		data: Record<string, string>,
+		redirectTo?: string,
+	): Promise<boolean> => {
 		// Refresh the CSRF token before attempting to sign in.
 		await refreshCsrfToken();
 
@@ -107,8 +110,8 @@ export const useSanctum = <TUser extends Record<string, unknown>>() => {
 			authenticated.value = true;
 
 			// Redirect if a redirect is provided.
-			if (config.login.redirectsTo) {
-				useRouter().push(config.login.redirectsTo);
+			if (redirectTo || config.login.redirectsTo) {
+				useRouter().push(redirectTo ?? config.login.redirectsTo);
 			}
 
 			return true;


### PR DESCRIPTION
This PR introduces an optional `redirectTo` parameter for the `login` method that allows overriding the after-login redirect URL.

closes #9 